### PR TITLE
Add Problem type to event response.

### DIFF
--- a/src/main/java/no/fint/event/model/Event.java
+++ b/src/main/java/no/fint/event/model/Event.java
@@ -311,14 +311,16 @@ public class Event<T> implements Serializable {
     /**
      * @return see {@link EventRequest} for more information.
      */
-    private EventRequest getRequest() {
+    @JsonIgnore
+    public EventRequest getRequest() {
         return request;
     }
 
     /**
      * @return see {@link EventResponse} for more information
      */
-    private EventResponse getResponse() {
+    @JsonIgnore
+    public EventResponse getResponse() {
         return response;
     }
 
@@ -360,6 +362,26 @@ public class Event<T> implements Serializable {
             response = new EventResponse();
         }
         response.setStatusCode(statusCode);
+    }
+
+    /**
+     * @return see {@link EventResponse#problems} for more information
+     */
+    public List<Problem> getProblems() {
+        if (response == null) {
+            response = new EventResponse();
+        }
+        return response.getProblems();
+    }
+
+    /**
+     * @param problems See {@link EventResponse#problems} for more information
+     */
+    public void setProblems(List<Problem> problems) {
+        if (response == null) {
+            response = new EventResponse();
+        }
+        response.setProblems(problems);
     }
 
     /**

--- a/src/main/java/no/fint/event/model/EventResponse.java
+++ b/src/main/java/no/fint/event/model/EventResponse.java
@@ -3,6 +3,7 @@ package no.fint.event.model;
 import lombok.Data;
 
 import java.io.Serializable;
+import java.util.List;
 
 @Data
 public class EventResponse implements Serializable {
@@ -24,4 +25,8 @@ public class EventResponse implements Serializable {
      */
     private ResponseStatus responseStatus;
 
+    /**
+     * Shows the problems the system has found when processing this event's request.
+     */
+    private List<Problem> problems;
 }

--- a/src/main/java/no/fint/event/model/Problem.java
+++ b/src/main/java/no/fint/event/model/Problem.java
@@ -1,0 +1,19 @@
+package no.fint.event.model;
+
+import lombok.Data;
+
+@Data
+public class Problem {
+    /**
+     * The name of the field the problem relates to.  Either a simple name or a JSON Path to the field.
+     */
+    private String field;
+    /**
+     * Human understandable message describing the problem.
+     */
+    private String message;
+    /**
+     * Machine traceable error code indicating the type of problem.
+     */
+    private String code;
+}

--- a/src/test/groovy/no/fint/event/model/EventSpec.groovy
+++ b/src/test/groovy/no/fint/event/model/EventSpec.groovy
@@ -1,5 +1,7 @@
 package no.fint.event.model
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import groovy.json.JsonSlurper
 import spock.lang.Specification
 
 class EventSpec extends Specification {
@@ -155,5 +157,34 @@ class EventSpec extends Specification {
         event.getResponseStatus() == ResponseStatus.ACCEPTED
         event.getMessage()
         event.getStatusCode()
+    }
+
+    def "Serialize response object to JSON"() {
+        given:
+        def event = new Event(action: 'UPDATE_SOMETHING', source: 'Spock', orgId: 'mock.no', client: 'none')
+
+        when:
+        event.setResponseStatus(ResponseStatus.ACCEPTED)
+        event.setMessage("Doubleplus super")
+        event.setStatusCode("R2D2")
+        event.setProblems([new Problem(field: "monkey", message: "Only chimpanzees allowed", code: 9999)])
+
+        then:
+        event.getResponseStatus() == ResponseStatus.ACCEPTED
+        event.getMessage()
+        event.getStatusCode()
+        event.getProblems().size() == 1
+
+        when:
+        def jsonSlurper = new JsonSlurper()
+        def objectMapper = new ObjectMapper()
+        def result = objectMapper.writeValueAsString(event.getResponse())
+        println(result)
+        def object = jsonSlurper.parseText(result)
+
+        then:
+        object
+        object.problems
+        object.responseStatus == "ACCEPTED"
     }
 }

--- a/src/test/groovy/no/fint/event/model/EventUtilSpec.groovy
+++ b/src/test/groovy/no/fint/event/model/EventUtilSpec.groovy
@@ -85,4 +85,44 @@ class EventUtilSpec extends Specification {
         event == null
     }
 
+    def "Read Event from event.json"() {
+        given:
+        def objectMapper = new ObjectMapper()
+        def json = "{\n" +
+                "  \"corrId\": \"a91cdb9b-0292-4baf-9a27-578642634129\",\n" +
+                "  \"action\": \"GET_ALL\",\n" +
+                "  \"status\": \"NEW\",\n" +
+                "  \"time\": 1524131147134,\n" +
+                "  \"orgId\": \"rogfk.no\",\n" +
+                "  \"source\": \"fk\",\n" +
+                "  \"client\": \"myClient\",\n" +
+                "  \"data\": [],\n" +
+                "  \"message\": \"There is a disturbance in the Force\",\n" +
+                "  \"query\": \"what\",\n" +
+                "  \"problems\": [\n" +
+                "    {\n" +
+                "      \"field\": \"monkey\",\n" +
+                "      \"message\": \"Only chimpanzees allowed\",\n" +
+                "      \"code\": \"9999\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"field\": \"jedi\",\n" +
+                "      \"message\": \"Luke not found\",\n" +
+                "      \"code\": \"44\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"statusCode\": \"JEDI-XX\",\n" +
+                "  \"responseStatus\": \"ERROR\"\n" +
+                "}"
+
+        when:
+        def event = objectMapper.readValue(getClass().getResourceAsStream("/event.json"), Event)
+
+        then:
+        event
+        event.problems.size() == 2
+        event.status == Status.NEW
+        event.responseStatus == ResponseStatus.ERROR
+        event.statusCode == "JEDI-XX"
+    }
 }

--- a/src/test/resources/event.json
+++ b/src/test/resources/event.json
@@ -1,0 +1,26 @@
+{
+  "corrId": "a91cdb9b-0292-4baf-9a27-578642634129",
+  "action": "GET_ALL",
+  "status": "NEW",
+  "time": 1524131147134,
+  "orgId": "rogfk.no",
+  "source": "fk",
+  "client": "myClient",
+  "data": [],
+  "message": "There is a disturbance in the Force",
+  "query": "what",
+  "problems": [
+    {
+      "field": "monkey",
+      "message": "Only chimpanzees allowed",
+      "code": "9999"
+    },
+    {
+      "field": "jedi",
+      "message": "Luke not found",
+      "code": "44"
+    }
+  ],
+  "statusCode": "JEDI-XX",
+  "responseStatus": "ERROR"
+}


### PR DESCRIPTION
Suggestion from Sam:

> Something like this would be very helpful:
```
{
	status: "failed",
	type: "variabelLonn"
	message: "Din betaling har en uautorisert attestant",
	problems: [
		{
			field: "attestant",
			message: "Ikke authorisert",
			code: 0123
		}
	],
	links: {
		self: "www.example.com/statuses/1234"
	}
}
```
> If we could have per-field errors it will benefit the user greatly.

The idea is to return the `EventResponse` object from status endpoints to support this.